### PR TITLE
Align the enter tags input section in subscriptions. Fixes issue #5191

### DIFF
--- a/app/views/home/subscriptions.html.erb
+++ b/app/views/home/subscriptions.html.erb
@@ -31,7 +31,7 @@
     <div class="form-group">
       <div class="row">
         <div class="col-md-7">
-          <input type="text" name="name" class="form-control" placeholder="<%= t('home.subscriptions.enter_tags') %>" data-provide="typeahead" data-source='["balloon-mapping","thermal-flashlight","spectrometer"]' autocomplete="off" required="required">
+          <input type="text" name="name" class="form-control text-center" placeholder="<%= t('home.subscriptions.enter_tags') %>" data-provide="typeahead" data-source='["balloon-mapping","thermal-flashlight","spectrometer"]' autocomplete="off" required="required">
         </div>
         <div class="col-md-2 pl-md-1">
           <button type="submit" class="btn btn-primary add-subscriptions"><i class="fa fa-plus fa fa-white"></i> <%= t('home.subscriptions.add') %></button>


### PR DESCRIPTION
Align the enter tags input section in subscriptions
Fixes #5191 at https://github.com/publiclab/plots2/issues/5191


